### PR TITLE
EN-2935, Send px_cookie_orig if cookie decryption failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ templates/
 untitled1/
 perimeterx_python_wsgi.egg-info/
 dist
+dev/

--- a/perimeterx/middleware.py
+++ b/perimeterx/middleware.py
@@ -125,7 +125,7 @@ class PerimeterX(object):
 
     def pass_traffic(self, environ, start_response, ctx):
         details = {}
-        if(ctx['decoded_cookie']):
+        if(ctx.get('decoded_cookie','')):
             details = {"px_cookie": ctx['decoded_cookie']}
         px_activities_client.send_to_perimeterx('page_requested', ctx, self.config, details)
         return self.app(environ, start_response)

--- a/perimeterx/px_api.py
+++ b/perimeterx/px_api.py
@@ -26,6 +26,7 @@ def verify(ctx, config):
 
 
 def prepare_risk_body(ctx, config):
+    logger = config['logger']
     body = {
         'request': {
             'ip': ctx.get('socket_ip'),
@@ -43,7 +44,13 @@ def prepare_risk_body(ctx, config):
             'risk_mode': config.get('module_mode', '')
         }
     }
-    if ctx.get('s2s_call_reason', '') in ['cookie_expired', 'cookie_validation_failed']:
+
+    if ctx['s2s_call_reason'] == 'cookie_decryption_failed':
+        logger.debug('attaching orig_cookie to request')
+        body['additional']['px_cookie_orig'] = ctx.get('px_orig_cookie')
+
+    if ctx['s2s_call_reason'] in ['cookie_expired', 'cookie_validation_failed']:
+        logger.debug('attaching px_cookie to request')
         body['additional']['px_cookie'] = ctx.get('decoded_cookie')
 
     return body

--- a/perimeterx/px_cookie.py
+++ b/perimeterx/px_cookie.py
@@ -160,6 +160,7 @@ def verify(ctx, config):
 
         if not decrypted_cookie:
             logger.error('Cookie decryption failed')
+            ctx['px_orig_cookie'] = px_cookie
             ctx['s2s_call_reason'] = 'cookie_decryption_failed'
             return False
 
@@ -168,6 +169,7 @@ def verify(ctx, config):
             decoded_cookie['s'], decoded_cookie['s']['b'], decoded_cookie['u'], decoded_cookie['t'], decoded_cookie['v']
         except:
             logger.error('Cookie decryption failed')
+            ctx['px_orig_cookie'] = px_cookie
             ctx['s2s_call_reason'] = 'cookie_decryption_failed'
             return False
 


### PR DESCRIPTION
fixed bug in middleware where it was checking decoded cookie and not returning empty
sending px_orig_cookie when decoding fail