### PR TITLE
[FIX] when verify throws an exception before creating a context objec…

### DIFF
--- a/perimeterx/middleware.py
+++ b/perimeterx/middleware.py
@@ -76,7 +76,7 @@ class PerimeterX(object):
             if ctx:
                 self.report_pass_traffic(ctx)
             else:
-                self.report_pass_traffic(PxContext({}, config))
+                self.report_pass_traffic(PxContext(Request({}), config))
             return True
 
 


### PR DESCRIPTION
…t, pass an empty Request object to PxContext